### PR TITLE
fix conditional parse logic for exponential numbers

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,24 +2,16 @@ import * as crypto from './crypto';
 
 export const debug = require('debug')('kms');
 
-const parse = (value) => {
+// exported for unit tests
+const isExpNumber = val => !Number.isNaN(Number(val)) && `${val}`.includes('E');
+export const parse = (value) => {
   /* istanbul ignore else */
-  if (value) {
-    // DEPRECATED - will remove this natural feature flag in future version
-    if (
-      !(value.startsWith('{') && value.endsWith('}')) && // ignore stringified object
-      !(value.startsWith('"') && value.endsWith('"')) && // ignore properly stringified string
-      value.split('E').length === 2 // without stringification it is impossible to tell a string that looks like an expo number from an actual number
-    ) {
-      // forwards compatibility for previousy non-stringified strings that look exponential
+  if (value && !isExpNumber(value)) {
+    try {
+      return JSON.parse(value);
+    } catch (e) /* istanbul ignore next */ {
+      // this will handle when the encrypted value was not stringified
       return value;
-    } else {
-      try {
-        return JSON.parse(value);
-      } catch (e) /* istanbul ignore next */ {
-        // this will handle when the encrypted value was not stringified
-        return value;
-      }
     }
   } else {
     return value;

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,7 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { encryptValue, decryptValue } from '../../src/utils';
+import { encryptValue, decryptValue, parse } from '../../src/utils';
 import * as crypto from '../../src/crypto';
 
 import { MOCK_GEN_DK_RESPONSE, MOCK_DECRYPT_DK_RESPONSE } from '../../src/fixtures';
@@ -50,5 +50,61 @@ describe('utils.js', () => {
       Plaintext: MOCK_DECRYPT_DK_RESPONSE.Plaintext,
     });
     expect(decrypted).to.deep.equal(VALUE2);
+  });
+  describe('parse', () => {
+    it('should parse stringified string', () => {
+      const original = 'some string';
+      const parsed = parse(JSON.stringify(original));
+
+      expect(parsed).to.equal(original);
+    });
+    it('should parse stringified object', () => {
+      const original = {
+        f1: 'single capital E but not a num',
+        f2: {
+          f3: 'nested',
+          f4: [{ f5: 'nested in array' }],
+        },
+      };
+      const parsed = parse(JSON.stringify(original));
+
+      expect(parsed).to.deep.equal(original);
+    });
+    it('should parse stringified array with field value: exponential string', () => {
+      const original = [
+        '33E44',
+      ];
+      const parsed = parse(JSON.stringify(original));
+
+      expect(parsed).to.deep.equal(original);
+    });
+    it('should parse stringified object with field value: exponential string', () => {
+      const original = {
+        f1: '33E44',
+      };
+      const parsed = parse(JSON.stringify(original));
+
+      expect(parsed).to.deep.equal(original);
+    });
+    it('should parse stringified object with field value: exponential number', () => {
+      const original = {
+        f1: 33E44,
+      };
+      const parsed = parse(JSON.stringify(original));
+
+      expect(parsed).to.deep.equal(original);
+    });
+    it('should parse stringified number', () => {
+      const original = 42;
+      const parsed = parse(JSON.stringify(original));
+
+      expect(parsed).to.deep.equal(original);
+    });
+    it('should NOT parse stringified exponential number', () => {
+      const original = '33E44';
+      const parsed = parse(original);
+
+      expect(parsed).to.equal(original);
+    });
   });
 });


### PR DESCRIPTION
The parse conditional logic doesn't properly account for a stringified array with a single `E` in it; The logic needs to more accurately exclude exponential-like numbers-as-string and allow everything else. This change uses native JavaScript logic for detecting numbers instead of manually splitting a string on E. The exp-number check also acts as a minimal exclude allowing everything else to be parsed without explicit specification. Unit tests added to cover the known cases.