### PR TITLE
update crypto-js to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-kms-ee",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1821,9 +1821,9 @@
       }
     },
     "crypto-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "date-fns": {
       "version": "1.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-kms-ee",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "AWS KMS Envelope Encryption",
   "main": "./lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sinon-chai": "^3.2.0"
   },
   "dependencies": {
-    "crypto-js": "^3.1.9-1"
+    "crypto-js": "^4.2.0"
   },
   "peerDependencies": {
     "bluebird": "^3.7.2",


### PR DESCRIPTION
veracode flags previous versions of crypto-js as potential vulnerabilities because of weak default hashing that was addressed in 4.2.0