### PR TITLE
Fix client logging.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,8 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-kms-ee",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-kms-ee",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-kms-ee",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AWS KMS Envelope Encryption",
   "main": "./lib/index.js",
   "files": [

--- a/src/connector.js
+++ b/src/connector.js
@@ -3,8 +3,7 @@ import Promise from 'bluebird';
 import memoryCache from 'memory-cache';
 import { DecryptCommand, EncryptCommand, GenerateDataKeyCommand, KMSClient } from '@aws-sdk/client-kms';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-
-import { debug } from './utils';
+import { getClientLogger } from './utils';
 
 const cache = new memoryCache.Cache();
 
@@ -23,7 +22,7 @@ class Connector {
         requestTimeout: timeout,
         connectionTimeout: connectTimeout,
       }),
-      logger: { log: /* istanbul ignore next */ msg => debug(msg) },
+      logger: getClientLogger(),
       region,
     });
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import { inspect } from 'util';
 import * as crypto from './crypto';
 
 export const debug = require('debug')('kms');
@@ -88,4 +89,15 @@ export const logError = (err, forEncrypt, region) => {
   const timestamp = Math.floor(Date.now() / 1000); // unix format
 
   return `MONITORING|${timestamp}|1|count|kms.error.count|#${flattenedTags}`;
+};
+
+export const getClientLogger = (dbg = debug) => {
+  const normalize = msg => (typeof msg === 'string' ? msg : inspect(msg, { depth: 3 })).replace(/\n/g, '\r');
+  const log = (...content) => dbg(...(content.map(normalize)));
+  return {
+    debug: () => {},
+    info: log,
+    warn: log,
+    error: log,
+  };
 };


### PR DESCRIPTION
The logging interface for aws sdk v3 changed from v2. This follows a similar pattern to the client logging in aws-lambda-stream library.

Missed this in my initial upgrade PR. Tested to verify sensitive information is not logged.
Output logs from kms-client look like:
```
2024-03-05T17:27:22.187Z kms {
  clientName: 'KMSClient',
  commandName: 'DecryptCommand',
  input: {
    CiphertextBlob: <Buffer 01 02 03 00 78 47 16 ad d7 c3 22 6d ec d1 57 c3 6b df 6b 44 59 1c 7e a9 2b 6c 07 b1 81 2c 7b e1 26 04 41 13 b9 01 7c 5b 2d 35 6e 91 ba c9 5c e8 85 ca ... 134 more bytes>
  },
  output: {
    EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
    KeyId: 'arn:aws:kms:us-east-1:<my aws account id redacted here>:key/dac69c83-0387-4109-8ed0-28b9dfba9d26',
    Plaintext: '***SensitiveInformation***'
  },
  metadata: {
    httpStatusCode: 200,
    requestId: 'e38f3da9-55e4-4991-89c0-d5c409c46957',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
```